### PR TITLE
Removes the smoothscroll class from body

### DIFF
--- a/src/layouts/master.hbs
+++ b/src/layouts/master.hbs
@@ -16,7 +16,7 @@
 		Background Image - add to body:
 			data-background="/theme_assets/images/boxed_background/1.jpg"
 	-->
-	<body class="{{ page.body_classes }} smoothscroll">
+	<body class="{{ page.body_classes }} ">
 
 		<div id="wrapper">
 			{{> header}}


### PR DESCRIPTION
This change allows users to decide how they want to handle scrolling rather than forcing it on them. Chrome as of version 49 automatically [includes smooth scrolling](https://developers.google.com/web/updates/2016/02/smooth-scrolling-in-chrome-49) and the setting is available on the preferences page at chrome://flags/#disable-smooth-scrolling. Myself and many others disable the feature. Smooth scrolling is like piloting a large boat in the water, where steering is sluggish and there's lag to everything you do. With smooth scrolling turned off, it's like driving a Formula-1 race car: scrolling is snappy and stops exactly when you want it to.
